### PR TITLE
support variable number of channels, png

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2018"
 [dependencies]
 thiserror = "1.0.25"
 tiff = "0.7.0"
+png = "0.16"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -137,12 +137,12 @@ mod tests {
 
     #[test]
     fn test_codec_12131() {
-        let frame = RGB48Frame::open("src/testdata/tears_of_steel_12130.tif").unwrap();
+        let frame = RGB48Frame::from_tiff("src/testdata/tears_of_steel_12130.tif").unwrap();
         assert_eq!(frame.data.len(), 4096 * 1714 * 3); // 42,123,264 bytes uncompressed
 
         let mut encoded = Vec::new();
         frame.encode::<Codec, _>(&mut encoded).unwrap();
-        assert_eq!(encoded.len(), 25526583);
+        assert_eq!(encoded.len(), 25526584);
 
         let decoded = RGB48Frame::decode::<Codec, _>(&*encoded, frame.width, frame.height).unwrap();
         assert_eq!(frame == decoded, true);
@@ -150,12 +150,12 @@ mod tests {
 
     #[test]
     fn test_codec_12209() {
-        let frame = RGB48Frame::open("src/testdata/tears_of_steel_12209.tif").unwrap();
+        let frame = RGB48Frame::from_tiff("src/testdata/tears_of_steel_12209.tif").unwrap();
         assert_eq!(frame.data.len(), 4096 * 1714 * 3); // 42,123,264 bytes uncompressed
 
         let mut encoded = Vec::new();
         frame.encode::<Codec, _>(&mut encoded).unwrap();
-        assert_eq!(encoded.len(), 28270586);
+        assert_eq!(encoded.len(), 28270587);
 
         let decoded = RGB48Frame::decode::<Codec, _>(&*encoded, frame.width, frame.height).unwrap();
         assert_eq!(frame == decoded, true);

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -2,6 +2,8 @@ use std::{
     io::{self, Read, Write},
     path::Path,
 };
+
+use super::bitstream::{Bitstream, BitstreamWriter};
 use thiserror::Error;
 
 pub struct Plane<T> {
@@ -29,6 +31,8 @@ pub enum FrameOpenError {
     IO(#[from] io::Error),
     #[error(transparent)]
     TiffError(#[from] tiff::TiffError),
+    #[error(transparent)]
+    PngError(#[from] png::DecodingError),
     #[error("unsupported color type: {0:?}")]
     UnsupportedColorType(tiff::ColorType),
     #[error("unsupported sample type")]
@@ -43,7 +47,20 @@ pub struct RGB48Frame {
 }
 
 impl RGB48Frame {
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, FrameOpenError> {
+    pub fn from_png<P: AsRef<Path>>(path: P) -> Result<Self, FrameOpenError> {
+        let decoder = png::Decoder::new(std::fs::File::open(path)?);
+        let (info, mut reader) = decoder.read_info()?;
+        let mut data = vec![0; info.buffer_size()];
+        reader.next_frame(&mut data)?;
+        let data = data.iter().map(|&x| x as u16).collect();
+        Ok(RGB48Frame {
+            data,
+            width: info.width as _,
+            height: info.height as _,
+        })
+    }
+
+    pub fn from_tiff<P: AsRef<Path>>(path: P) -> Result<Self, FrameOpenError> {
         let f = std::fs::File::open(path)?;
         let mut dec =
             tiff::decoder::Decoder::new(f)?.with_limits(tiff::decoder::Limits::unlimited());
@@ -63,32 +80,24 @@ impl RGB48Frame {
     }
 
     pub fn planes(&self) -> Vec<Plane<&[u16]>> {
-        vec![
-            Plane {
-                data: &self.data,
+        let n_planes = self.data.len() / (self.width * self.height);
+        return (0..n_planes)
+            .map(|plane| Plane {
+                data: &self.data[plane..],
                 width: self.width,
                 height: self.height,
-                row_stride: 3 * self.width,
-                sample_stride: 3,
-            },
-            Plane {
-                data: &self.data[1..],
-                width: self.width,
-                height: self.height,
-                row_stride: 3 * self.width,
-                sample_stride: 3,
-            },
-            Plane {
-                data: &self.data[2..],
-                width: self.width,
-                height: self.height,
-                row_stride: 3 * self.width,
-                sample_stride: 3,
-            },
-        ]
+                row_stride: n_planes * self.width,
+                sample_stride: n_planes,
+            })
+            .collect();
     }
 
     pub fn encode<C: Codec, W: Write>(&self, mut dest: W) -> io::Result<()> {
+        {
+            let mut bitstream = BitstreamWriter::new(&mut dest);
+            bitstream.write_bits((self.planes().len() - 1) as _, 2)?;
+            bitstream.flush()?;
+        }
         for plane in self.planes() {
             C::encode(&plane, &mut dest)?;
         }
@@ -100,20 +109,24 @@ impl RGB48Frame {
         width: usize,
         height: usize,
     ) -> io::Result<Self> {
+        let n_planes = {
+            let mut bitstream = Bitstream::new(&mut source);
+            (bitstream.read_bits(2)? as usize) + 1
+        };
         let mut ret = Self {
-            data: vec![0; width * height * 3],
+            data: vec![0; width * height * n_planes],
             width,
             height,
         };
-        for plane in 0..3 {
+        for plane in 0..n_planes {
             C::decode(
                 &mut source,
                 &mut Plane {
                     data: &mut ret.data[plane..],
                     width: width,
                     height: height,
-                    row_stride: 3 * width,
-                    sample_stride: 3,
+                    row_stride: n_planes * width,
+                    sample_stride: n_planes,
                 },
             )?;
         }
@@ -127,6 +140,6 @@ mod tests {
 
     #[test]
     fn test_rgb48_frame_open() {
-        RGB48Frame::open("src/testdata/tears_of_steel_12130.tif").unwrap();
+        RGB48Frame::from_tiff("src/testdata/tears_of_steel_12130.tif").unwrap();
     }
 }


### PR DESCRIPTION
Uses two bits to encode number of planes (1, 2, 3, or 4); implement reading png file. tested on monochrome and rgb png files.

For example to run on the Lossless Photo Compression Benchmark, we can download `LPCB.7z` from [google drive](https://drive.google.com/drive/u/1/folders/1X_F_vhNwJFhPWSW3EeSa-gGhhikkOoYd) and then run the following program:

```rust
extern crate hello_video_codec as hvc;
fn main() {
    let mut size = 0;
    let mut encode_time = std::time::Duration::new(0, 0);
    let mut decode_time = std::time::Duration::new(0, 0);
    for img in std::env::args().skip(1) {
        let frame = hvc::frame::RGB48Frame::from_png(&img).unwrap();

        let mut encoded = Vec::new();
        let now = std::time::Instant::now();
        frame.encode::<hvc::codec::Codec, _>(&mut encoded).unwrap();
        encode_time += now.elapsed();

        size += encoded.len();

        let now = std::time::Instant::now();
        let decoded = hvc::frame::RGB48Frame::decode::<hvc::codec::Codec, _>(
            &*encoded,
            frame.width,
            frame.height,
        )
        .unwrap();
        decode_time += now.elapsed();
        assert_eq!(frame == decoded, true);
        println!("{} : {} --> {}", &img, frame.data.len(), encoded.len());
    }
    println!("encode time: {} ms", encode_time.as_millis());
    println!("decode time: {} ms", decode_time.as_millis());
    println!("size: {} bytes", size);
}
```

We note that `LPCB.7z` contains a monochrome PNG file 

```
identify /Users/dllu/Downloads/LPCB/PIA13943.png
/Users/dllu/Downloads/LPCB/PIA13943.png PNG 3000x2400 3000x2400+0+0 8-bit Gray 256c 560526B 0.000u 0:00.000
```